### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-#LICENSE
+# LICENSE
 
 ***
 
@@ -6,7 +6,7 @@
 
 ***
 
-##PERMISSIONS
+## PERMISSIONS
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software, specifically granting the rights to do the following: 
 
 * Use the Software in derivative works.
@@ -15,14 +15,14 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 * Merge the Software with derivative works.
 * Sell derivative works containing the Software. 
 
-##PROHIBITIONS
+## PROHIBITIONS
 It is specifically prohibited to do the following: 
 
 * Sell Fremont as a stand-alone product, and/or outside the scope of a derivative work. 
 * Use Fremont in any capacity without including this license notice in its entirety.
 * Use Fremont in any capacity without proper attribution (detailed below).
 
-##CONDITIONS
+## CONDITIONS
 These terms are subject to the following conditions:
 
 * This license notice in its entirety shall be included in all copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#README
+# README
 
 ***
 
@@ -6,15 +6,15 @@
 
 ***
 
-##SOURCE CODE
+## SOURCE CODE
 Source code for both the Fremont static library project and the sample iPhone project can be found in the ./Code directory.
 
-##DOCUMENTATION
+## DOCUMENTATION
 The original documentation file (Pages format) and an exported PDF version of the Pages file can be found in the ./Documentation directory.
 
-##GRAPHICS
+## GRAPHICS
 Relevant raw graphics files used to produce graphic assets for the sample source code project can be found in the ./Graphics directory.
 
-##LICENSE
+## LICENSE
 The Fremont XML Library license can be found in the LICENSE.md file.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
